### PR TITLE
Remove "polymer-" prefix

### DIFF
--- a/element/index.js
+++ b/element/index.js
@@ -90,8 +90,8 @@ Generator.prototype.createElementFiles = function createElementFiles() {
      this.addImportToFile({
       fileName:  'index.html',
       importUrl: 'elements/' + this.name + '.html',
-      tagName: 'polymer-' + this.name
-    });   
+      tagName: this.name
+    });
   }
 };
 

--- a/templates/polymer-element.html
+++ b/templates/polymer-element.html
@@ -1,6 +1,6 @@
 <link rel="import" href="../bower_components/polymer/polymer.html">
 
-<polymer-element name="polymer-<%= name %>" <% if (includeConstructor) { %> constructor="<%= _.classify(name) %>Element"<% } %> attributes="">
+<polymer-element name="<%= name %>" <% if (includeConstructor) { %> constructor="<%= _.classify(name) %>Element"<% } %> attributes="">
   <template>
     <style>
       /* styles for the custom element itself - lowest specificity */
@@ -10,10 +10,10 @@
       :host(.different) { } 
       */
     </style>
-    <span>I'm <b>polymer-<%= _.camelize(name) %></b>. This is my Shadow DOM.</span>
+    <span>I'm <b><%= _.camelize(name) %></b>. This is my Shadow DOM.</span>
   </template>
   <script>
-    Polymer('polymer-<%= name %>', {
+    Polymer('<%= name %>', {
       // element is fully prepared
       ready: function(){ },
       // instance of the element is created


### PR DESCRIPTION
We shouldn't encourage people to use those prefixes:

http://webcomponents.github.io/articles/how-should-i-name-my-element/

According to Scott Miles on Polymer mailing list:

"The intent of the 'polymer-*' prefix in our stuff is to indicate 'elements
made by the polymer team', and not 'element made using polymer'.

Because part of the notion of Polymer is that users of an element don't
necessarily _need_ to know it's made with Polymer (it should Just Work)
then don't feel like you need to identify it as such with 'polymer-*'"
