### PR TITLE
Change bowerc and import paths to bower_components instead of ../

### DIFF
--- a/app/templates/_demo.html
+++ b/app/templates/_demo.html
@@ -4,7 +4,7 @@
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
   <title><%= _.slugify(elementName) %> Demo</title>
 
-  <script src="../platform/platform.js"></script>
+  <script src="bower_components/platform/platform.js"></script>
   <link rel="import" href="<%= _.slugify(elementName) %>.html">
 
 </head>

--- a/app/templates/_index.html
+++ b/app/templates/_index.html
@@ -2,9 +2,9 @@
 <html>
 <head>
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-  <script src="../platform/platform.js"></script>
-  <link rel="import" href="../polymer/polymer.html">
-  <link rel="import" href="../core-component-page/core-component-page.html">
+  <script src="bower_components/platform/platform.js"></script>
+  <link rel="import" href="bower_components/polymer/polymer.html">
+  <link rel="import" href="bower_components/core-component-page/core-component-page.html">
 
 </head>
 <body unresolved>

--- a/app/templates/_seed-element.html
+++ b/app/templates/_seed-element.html
@@ -1,4 +1,4 @@
-<link rel="import" href="../polymer/polymer.html">
+<link rel="import" href="bower_components/polymer/polymer.html">
 
 <!--
 Element providing solution to no problem in particular.

--- a/app/templates/bowerrc
+++ b/app/templates/bowerrc
@@ -1,3 +1,3 @@
 {
-  "directory": "../"
+  "directory": "bower_components/"
 }

--- a/app/templates/gitignore
+++ b/app/templates/gitignore
@@ -1,4 +1,5 @@
 node_modules
+bower_components
 dist
 .sass-cache
 .tmp


### PR DESCRIPTION
Currently the generated component has bowerrc and import paths with `../`. This makes the `bower install` command install dependencies outside of the project root folder.

If there's a better reason for using `../` instead of `bower_components`, please let me know and ignore this PR :)

Cheers!

**Edit:** I also think that #36 is related with this. If you have lots of project folders in `../`, maybe bower is searching for `bower.json` files.
