### PR TITLE
Having dist in .gitignore prevents gp.sh from adding some bower deps to gh-pages branch

### DIFF
--- a/app/templates/gitignore
+++ b/app/templates/gitignore
@@ -1,4 +1,3 @@
 node_modules
-dist
 .sass-cache
 .tmp


### PR DESCRIPTION
Hi again, apologies for submitting so many of these so quickly!

One of my projects uses video.js as a dependency, which puts its built versions in a `dist` folder. Because `gp.sh` ultimately adheres to the `.gitignore` in the `master` branch when building the `gh-pages` branch, such dependencies are never included. This could be an incredibly difficult thing to troubleshoot if unaware of this fact (indeed, I've done so twice now and each time it's been somewhat of a head-scratcher, even though I've had a pretty decent idea of what's going on).

If #41 is merged, all dependencies are in the `development` parent directory and having `dist` in `.gitignore` is unnecessary (at least, if git is initialised in the component directory itself and not the parent). 

I admittedly may be missing something — feel free to close if so.
