### PR TITLE
Auto generate imports in elements.html

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -65,6 +65,7 @@ module.exports = yeoman.generators.Base.extend({
     this.template('app/favicon.ico');
     this.template('app/robots.txt');
     this.copy('app/htaccess', 'app/.htaccess');
+    this.copy('app/elements.html', 'app/elements/elements.html');
     this.copy('app/yo-list.html', 'app/elements/yo-list.html');
     this.copy('app/yo-greeting.html', 'app/elements/yo-greeting.html');
     this.write('app/index.html', this.indexFile);

--- a/app/templates/app/elements.html
+++ b/app/templates/app/elements.html
@@ -1,0 +1,2 @@
+<link rel="import" href="yo-list.html">
+<link rel="import" href="yo-greeting.html">

--- a/app/templates/index.html
+++ b/app/templates/index.html
@@ -14,8 +14,7 @@
 
         <!-- Place your HTML imports here -->
         <script src="bower_components/platform/platform.js"></script>
-        <link rel="import" href="elements/yo-list.html">
-        <link rel="import" href="elements/yo-greeting.html">
+        <link rel="import" href="elements/elements.html">
     </head>
     <body unresolved>
 

--- a/el/index.js
+++ b/el/index.js
@@ -17,6 +17,12 @@ module.exports = yeoman.generators.Base.extend({
       return;
     }
 
+    // Create the template element
     this.template('_element.html', 'app/elements/' + this.elementName + '.html');
+
+    // Wire up the dependency in elements.html
+    var file = this.readFileAsString('app/elements/elements.html');
+    file += '<link rel="import" href="' + this.elementName + '.html">\n';
+    this.writeFileFromString(file, 'app/elements/elements.html');
   }
 });

--- a/test/app-test.js
+++ b/test/app-test.js
@@ -3,7 +3,7 @@
 var path    = require('path');
 var helpers = require('yeoman-generator').test;
 
-describe('Polymer generator test', function () {
+describe('yo polymer:app test', function () {
   before(function (done) {
     helpers.testDirectory(path.join(__dirname, 'temp'), function (err) {
       if (err) {
@@ -43,6 +43,7 @@ describe('Polymer generator test', function () {
       'app/favicon.ico',
       'app/.htaccess',
       'app/robots.txt',
+      'app/elements/elements.html',
       'app/elements/yo-greeting.html',
       'app/elements/yo-list.html'
     ];

--- a/test/el-test.js
+++ b/test/el-test.js
@@ -3,20 +3,29 @@
 var path    = require('path');
 var helpers = require('yeoman-generator').test;
 
-describe('Polymer generator test', function () {
+describe('yo polymer:el test', function () {
   before(function (done) {
     helpers.testDirectory(path.join(__dirname, 'temp'), function (err) {
       if (err) {
         return done(err);
       }
 
-      this.polymer = helpers.createGenerator('polymer:el', [
+      // Create the polymer:app generator
+      this.polymer = helpers.createGenerator('polymer:app', [
+        '../../app', [
+          helpers.createDummyGenerator(),
+          'mocha:app'
+        ]
+      ]);
+      this.polymer.options['skip-install'] = true;
+
+      // Create the polymer:el generator
+      this.element = helpers.createGenerator('polymer:el', [
         '../../el', [
           helpers.createDummyGenerator(),
           'mocha:el'
         ]
       ], 'x-foo');
-      this.polymer.options['skip-install'] = true;
 
       done();
     }.bind(this));
@@ -32,10 +41,19 @@ describe('Polymer generator test', function () {
       'app/elements/x-foo.html'
     ];
 
-    this.polymer.run({}, function () {
-      helpers.assertFiles(expected);
-      done();
+    helpers.mockPrompt(this.polymer, {
+      includeCore: true,
+      includePaper: true
     });
+
+    // Run the polymer:app generator
+    this.polymer.run({}, function () {
+      // Then run the polymer:el generator
+      this.element.run({}, function() {
+        helpers.assertFiles(expected);
+        done();
+      });
+    }.bind(this));
   });
 
 });

--- a/test/seed-test.js
+++ b/test/seed-test.js
@@ -3,7 +3,7 @@
 var path    = require('path');
 var helpers = require('yeoman-generator').test;
 
-describe('Polymer generator test', function () {
+describe('yo polymer:seed test', function () {
   before(function (done) {
     helpers.testDirectory(path.join(__dirname, 'temp'), function (err) {
       if (err) {


### PR DESCRIPTION
This creates an `app/elements/elements.html` file that holds all of the imports for the site. When you run `yo polymer:el x-foo` it will add the element's import to `app/elements/elements.html` so you don't have to wire anything up. @addyosmani PTAL
