### PR TITLE
Remove `use strict` in elements. Fixes #80

### DIFF
--- a/app/templates/app/yo-greeting.html
+++ b/app/templates/app/yo-greeting.html
@@ -9,7 +9,6 @@
   </template>
   <script>
     (function () {
-      'use strict';
 
       Polymer({
         greeting : '\'Allo'

--- a/app/templates/app/yo-list.html
+++ b/app/templates/app/yo-list.html
@@ -11,7 +11,6 @@
   </template>
   <script>
     (function () {
-      'use strict';
 
       Polymer({
         ready: function() {

--- a/el/templates/_element.html
+++ b/el/templates/_element.html
@@ -11,7 +11,6 @@
   </template>
   <script>
     (function () {
-      'use strict';
 
       Polymer({
         // define element prototype here


### PR DESCRIPTION
Unfortunately you can only use `strict` mode if you never use `super()`. There is at present no workaround to this problem and so we need to drop this from the element boilerplate.
