### PR TITLE
Change backslashes in link tag in elements.html

### DIFF
--- a/el/index.js
+++ b/el/index.js
@@ -61,7 +61,7 @@ module.exports = yeoman.generators.Base.extend({
     // Wire up the dependency in elements.html
     if (this.includeImport) {
       var file = this.readFileAsString('app/elements/elements.html');
-	  el = el.replace('\\', '/');
+      el = el.replace('\\', '/');
       file += '<link rel="import" href="' + el + '.html">\n';
       this.writeFileFromString(file, 'app/elements/elements.html');
     }


### PR DESCRIPTION
In the file `app\elements\elements.html`:
`<link rel="import" href="my-element\my-element.html">`
should be 
`<link rel="import" href="my-element/my-element.html">`

The elements.html file, has a link tag with an href attribute.  The
value of href on Windows is rendered with backslashes instead of forward
slashes. Changed.
