### PR TITLE
Use appname property as title for index.html page. Closes #66

### DIFF
--- a/app/templates/app/index.html
+++ b/app/templates/app/index.html
@@ -4,7 +4,7 @@
 <head>
   <meta charset="utf-8">
   <meta http-equiv="X-UA-Compatible" content="IE=edge">
-  <title>Polymer WebApp</title>
+  <title><%= appname %></title>
   <meta name="description" content="">
   <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
   <!-- Place favicon.ico and apple-touch-icon.png in the root directory -->


### PR DESCRIPTION
This PR proposes to use the  `<%= appname %>` property as value for a generated `index.html` `title` tag. This will fully meet the issue main request I believe.
This PR uses solution based on `generator-webapp` solution trying to keep in line with other solutions in Yeoman family:
http://git.io/tQTwwQ
Other Yeoman generators either do not set title value at all (most of them I think) - contrary to this generator.

Generated titles:

``` json
"name": "app-polymer"
```

``` html
<title>app polymer</title>
```

``` json
"name": "mypolymerapp"
```

``` html
<title>MyPolymerApp</title>
```

```
Uses the application name property as the title of a generated
index.html document. Based on generator-webapp solution:
http://git.io/tQTwwQ
```

tests:
https://gist.github.com/peterblazejewicz/2743b387be412faa3ef1
