### PR TITLE
Added the ability to include devDependencies in GitHub Pages. Fixes #61

### DIFF
--- a/gh/index.js
+++ b/gh/index.js
@@ -7,6 +7,14 @@ var spawn = require('child_process').spawn;
 var rimraf = require('rimraf');
 
 module.exports = yeoman.generators.Base.extend({
+  constructor: function () {
+    yeoman.generators.Base.apply(this, arguments);
+    this.option('nodevdeps', {
+      desc: 'Whether devDependencies should be installed in the gh-pages branch',
+      default: false
+    });
+    this.includeDevDeps = this.options.nodevdeps ? 'no' : 'yes';
+  },
   askFor: function () {
     var done = this.async();
 
@@ -23,19 +31,12 @@ module.exports = yeoman.generators.Base.extend({
         name: 'elementName',
         message: 'What is your element\'s name',
         default: defaultName
-      },
-      {
-        name: 'includeDevDeps',
-        message: 'Would you like to include the devDependencies from your bower.json file?',
-        type: 'confirm',
-        default: false
       }
     ];
 
     this.prompt(prompts, function (props) {
       this.ghUser = props.ghUser;
       this.elementName = props.elementName;
-      this.includeDevDeps = props.includeDevDeps ? 'yes' : 'no';
 
       done();
     }.bind(this));

--- a/gh/index.js
+++ b/gh/index.js
@@ -23,12 +23,19 @@ module.exports = yeoman.generators.Base.extend({
         name: 'elementName',
         message: 'What is your element\'s name',
         default: defaultName
+      },
+      {
+        name: 'includeDevDeps',
+        message: 'Would you like to include the devDependencies from your bower.json file?',
+        type: 'confirm',
+        default: false
       }
     ];
 
     this.prompt(prompts, function (props) {
       this.ghUser = props.ghUser;
       this.elementName = props.elementName;
+      this.includeDevDeps = props.includeDevDeps ? 'yes' : 'no';
 
       done();
     }.bind(this));
@@ -44,7 +51,7 @@ module.exports = yeoman.generators.Base.extend({
         return this.log(err);
       }
 
-      var gp = spawn('sh', ['gp.sh', this.ghUser, this.elementName], {cwd: dest});
+      var gp = spawn('sh', ['gp.sh', this.ghUser, this.elementName, this.includeDevDeps], {cwd: dest});
 
       gp.stdout.on('data', function (data) {
         this.log(data.toString());

--- a/gh/templates/gp.sh
+++ b/gh/templates/gp.sh
@@ -7,6 +7,7 @@
 # Run in a clean directory passing in a GitHub org and repo name
 org=$1
 repo=$2
+getdevdeps=$3
 
 # make folder (same as input, no checking!)
 mkdir $repo
@@ -25,6 +26,15 @@ bower install --config.directory="components" $org/$repo#master
 
 # redirect by default to the component folder
 echo "<META http-equiv="refresh" content=\"0;URL=components/$repo/\">" >index.html
+
+
+# install the project's dev dependencies
+if [ "$getdevdeps" = "yes" ]
+then
+  cd components/$repo
+  bower install --config.directory="../"
+  cd ../../
+fi
 
 # send it all to github
 git add -A .

--- a/readme.md
+++ b/readme.md
@@ -91,6 +91,8 @@ yo polymer:seed x-foo
 ### Gh
 Generates a Github pages branch for your [seed-element](#seed).
 
+If your documentation or demo pages have dependencies declared as devDependencies in bower.json, you can include them in the Github pages branch by answering _yes_ to the relevant question.
+
 Example:
 ```bash
 cd components/x-foo

--- a/readme.md
+++ b/readme.md
@@ -91,13 +91,15 @@ yo polymer:seed x-foo
 ### Gh
 Generates a Github pages branch for your [seed-element](#seed).
 
-If your documentation or demo pages have dependencies declared as devDependencies in bower.json, you can include them in the Github pages branch by answering _yes_ to the relevant question.
+If your documentation or demo pages have dependencies declared as devDependencies in `bower.json`, they will be included in your GitHub pages branch.
 
 Example:
 ```bash
 cd components/x-foo
 yo polymer:gh
 ```
+
+If, for some reason, you don't want the devDependencies, use the `--nodevdeps` option.
 
 ## Testing
 


### PR DESCRIPTION
I wanted to generate nice looking demo pages for my elements that use other Polymer elements, but didn't want those elements as dependencies for my element.

Therefore, I added them as devDependencies, using `$ bower install --save-dev <my-deps>`.

Problem was, the way the GitHub Pages generation is done has bower install my element into a fresh directory, which prevents it from installing the devDependencies (this is the default bower behavior, don't know of a workaround).

I added another (optional) step: since we already have the repository pulled for us, we go into it and install the dependencies into the parent dir. This installs the devDependencies and we now have our desired elements without having them as dependencies for the element itself.