### PR TITLE
Allow an alternate port to be specified when running grunt serve

### DIFF
--- a/app/templates/Gruntfile.js
+++ b/app/templates/Gruntfile.js
@@ -115,7 +115,7 @@ module.exports = function (grunt) {
     },
     connect: {
       options: {
-        port: 9000,
+        port: grunt.option('port') || 9000,
         // change this to '0.0.0.0' to access the server from outside
         hostname: 'localhost'
       },


### PR DESCRIPTION
As xdebug runs on port 9000, I often need to change the port that livereload connects to.

With this change, the port can be specified on the command line: `grunt serve --port=9100`