### PR TITLE
Update gitignore to correct bower_components path

### DIFF
--- a/app/templates/gitignore
+++ b/app/templates/gitignore
@@ -2,6 +2,6 @@ node_modules
 dist
 test/temp
 .sass-cache
-app/bower_components
+bower_components
 .tmp
 test/bower_components/


### PR DESCRIPTION
Change location of .gitignore path to bower_components which is now at the root level and not inside the app folder