### PR TITLE
Vulcanize & minify polymer.js

### DIFF
--- a/app/templates/gulpfile.js
+++ b/app/templates/gulpfile.js
@@ -146,8 +146,13 @@ gulp.task('vulcanize', function () {
   return gulp.src('dist/elements/elements.vulcanized.html')
     .pipe($.vulcanize({
       dest: DEST_DIR,
-      strip: true
+      strip: true,
+      csp: true,
+      inline: true
     }))
+    .pipe($.if('*.js', $.uglify({
+      preserveComments: 'some'
+    })))
     .pipe(gulp.dest(DEST_DIR))
     .pipe($.size({title: 'vulcanize'}));
 });


### PR DESCRIPTION
Using the `csp` and `inline` options generates a `elements.vulcanized.js`, but it's not minified.
Adding an `uglify` task to the pipe does it.

Fixes #151 