### PR TITLE
Vulcanize the seed element to a single file for gh-pages

### DIFF
--- a/gh/templates/gp.sh
+++ b/gh/templates/gp.sh
@@ -36,6 +36,9 @@ then
   cd ../../
 fi
 
+# vulcanize the element to a single file
+vulcanize --inline --strip --output $repo.html components/$repo/$repo.html
+
 # send it all to github
 git add -A .
 git commit -am 'seed gh-pages'

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
     "ncp": "^2.0.0",
     "rimraf": "^2.2.8",
     "validate-element-name": "^1.0.0",
+    "vulcanize": "^1.1.0",
     "yeoman-generator": "^0.18.8",
     "yosay": "^1.0.0"
   },


### PR DESCRIPTION
So that the element can be imported as a stand-alone web component from `https://{user}.github.io/{element-name}/{element-name}.html`, this vulcanizes the seed element to a single file when deploying to GitHub Pages, 

There might be a better way to do this (or it might turn out to be unnecessary), so this is just a suggestion.