### PR TITLE
404 page: remove IE6/7 CSS hacks

### DIFF
--- a/app/templates/app/404.html
+++ b/app/templates/app/404.html
@@ -32,7 +32,6 @@
 
       body {
         max-width: 500px;
-        _width: 500px;
         padding: 30px 20px 50px;
         border: 1px solid #b3b3b3;
         border-radius: 4px;
@@ -66,7 +65,6 @@
 
       .container {
         max-width: 380px;
-        _width: 380px;
         margin: 0 auto;
       }
 
@@ -114,9 +112,6 @@
         -webkit-appearance: none;
         -moz-appearance: none;
         appearance: none;
-        *overflow: visible;
-        *display: inline;
-        *zoom: 1;
       }
 
       #goog-wm-sb:hover,


### PR DESCRIPTION
Not needed at our level of browser support. This happened in other generators that use the same 404 page as well (e.g. https://github.com/yeoman/generator-backbone/pull/334)