### PR TITLE
Fix #171. Added alternative search path for bower folder

### DIFF
--- a/app/templates/app/index.html
+++ b/app/templates/app/index.html
@@ -12,7 +12,7 @@
   <link rel="stylesheet" href="styles/main.css">
   <!-- endbuild-->
 
-  <!-- build:js bower_components/webcomponentsjs/webcomponents.min.js -->
+  <!-- build:js(.) bower_components/webcomponentsjs/webcomponents.min.js -->
   <script src="bower_components/webcomponentsjs/webcomponents.js"></script>
   <!-- endbuild -->
 


### PR DESCRIPTION
Issue #171is caused by the useminPrepare:html task.

If you see the `grunt --verbose` output task you will see the following (note the `bower_components/webcomponentsjs/webcomponents.js` path which is located inside the app folder instead of being in the root folder):

```
Running "useminPrepare:html" (useminPrepare) task
Verifying property useminPrepare.html exists in config...OK
Files: app/index.html -> html
Options: dest="dist"
Going through app/index.html to update the config
Looking for build script HTML comment blocks

Configuration is now:

  concat:
  { generated: 
   { files: 
      [ { dest: '.tmp/concat/styles/main.css',
          src: [ 'app/styles/main.css' ] },
        { dest: '.tmp/concat/bower_components/webcomponentsjs/webcomponents.min.js',
          src: [ 'app/bower_components/webcomponentsjs/webcomponents.js' ] },
        { dest: '.tmp/concat/scripts/app.js',
          src: [ 'app/scripts/app.js' ] } ] } }

  uglify:
  { generated: 
   { files: 
      [ { dest: 'dist/bower_components/webcomponentsjs/webcomponents.min.js',
          src: [ '.tmp/concat/bower_components/webcomponentsjs/webcomponents.min.js' ] },
        { dest: 'dist/scripts/app.js',
          src: [ '.tmp/concat/scripts/app.js' ] } ] } }
```

By adding `(.)` as part of the build declaration in the index.html template file this issue is fixed. You can see more information about setting an _alternate search path_ at https://github.com/yeoman/grunt-usemin#blocks.

```<!-- build:js(.) bower_components/webcomponentsjs/webcomponents.min.js -->```
