### PR TITLE
Move script into dom-module (preferred location)

### DIFF
--- a/app/templates/polymer-starter-kit/app/elements/my-greeting/my-greeting.html
+++ b/app/templates/polymer-starter-kit/app/elements/my-greeting/my-greeting.html
@@ -26,19 +26,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
     <!-- Listens for "input" event and sets greeting to <input>.value -->
     <input class="paper-font-body2" value="{{greeting::input}}">
   </template>
-</dom-module>
-<script>
-  (function() {
-    Polymer({
-      is: 'my-greeting',
+  <script>
+    (function() {
+      Polymer({
+        is: 'my-greeting',
 
-      properties: {
-        greeting: {
-          type: String,
-          value: 'Welcome!',
-          notify: true
+        properties: {
+          greeting: {
+            type: String,
+            value: 'Welcome!',
+            notify: true
+          }
         }
-      }
-    });
-  })();
-</script>
+      });
+    })();
+  </script>
+</dom-module>

--- a/app/templates/polymer-starter-kit/app/elements/my-list/my-list.html
+++ b/app/templates/polymer-starter-kit/app/elements/my-list/my-list.html
@@ -21,27 +21,27 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
       </template>
     </ul>
   </template>
-</dom-module>
-<script>
-  (function () {
-    Polymer({
-      is: 'my-list',
-      properties: {
-        items: {
-          type: Array,
-          notify: true,
+  <script>
+    (function () {
+      Polymer({
+        is: 'my-list',
+        properties: {
+          items: {
+            type: Array,
+            notify: true,
+          }
+        },
+        ready: function() {
+          this.items = [
+            'Responsive Web App boilerplate',
+            'Iron Elements and Paper Elements',
+            'End-to-end Build Tooling (including Vulcanize)',
+            'Unit testing with Web Component Tester',
+            'Routing with Page.js',
+            'Offline support with the Platinum Service Worker Elements'
+          ];
         }
-      },
-      ready: function() {
-        this.items = [
-          'Responsive Web App boilerplate',
-          'Iron Elements and Paper Elements',
-          'End-to-end Build Tooling (including Vulcanize)',
-          'Unit testing with Web Component Tester',
-          'Routing with Page.js',
-          'Offline support with the Platinum Service Worker Elements'
-        ];
-      }
-    });
-  })();
-</script>
+      });
+    })();
+  </script>
+</dom-module>

--- a/el/templates/element.html
+++ b/el/templates/element.html
@@ -20,19 +20,19 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <template>
     <div>Hello from <span>{{foo}}</span></div>
   </template>
-</dom-module>
-<script>
-(function() {
-  Polymer({
-    is: '<%= elementName %>',
+  <script>
+  (function() {
+    Polymer({
+      is: '<%= elementName %>',
 
-    properties: {
-      foo: {
-        type: String,
-        value: 'bar',
-        notify: true
+      properties: {
+        foo: {
+          type: String,
+          value: 'bar',
+          notify: true
+        }
       }
-    }
-  });
-})();
-</script>
+    });
+  })();
+  </script>
+</dom-module>


### PR DESCRIPTION
The generator placed the `<script>` tag in the root of the document, while Polymer 1.0 documentation currently shows it only inside of the `<dom-module>`.

While it's functionally equivalent (as far as I'm aware) to place `<script>` in either location, the supposedly new "preferred location" is inside the `<dom-module>` based on [Mauro Solcia's](https://plus.google.com/117141236479651677751) comment on a [Polymer G+ post](https://plus.google.com/109750283631852123540/posts/7PuC8eccvhR):
> A small note is to put the `<script>` inside the `<dom-module>` tag, as it's the new preferred way to improve code readability/feeling of encapsulation (documentation is being updated accordingly).﻿

This patch moves `<script>` into `<dom-module>` for the reason mentioned above and to maintain consistency with official Polymer documentation.