### PR TITLE
Remove `generator-mocha` peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,9 +24,6 @@
     "yeoman-generator": "^0.18.8",
     "yosay": "^1.0.0"
   },
-  "peerDependencies": {
-    "generator-mocha": ">=0.1.3"
-  },
   "devDependencies": {
     "jshint": "*",
     "mocha": "*"


### PR DESCRIPTION
This wasn't used anywhere from what I can see.