### PR TITLE
Remove use strict

### DIFF
--- a/el/templates/element.html
+++ b/el/templates/element.html
@@ -22,7 +22,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   </template>
   <script>
   (function() {
-    'use strict';
 
     Polymer({
       is: '<%= elementName %>',


### PR DESCRIPTION
Having `use strict` causes errors when running gulp or gulp serve:dist such as:

you get an error `Error in plugin 'gulp-jshint'
Message:
    JSHint failed for: /Users/chuckh/DevPolymerLocal/ygp1/app/elements/my-element/my-element.html`

`line 28  col 3  Missing 'new' prefix when invoking a constructor.`