### PR TITLE
Added polymer:bower sub generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
 tmp/
 .DS_Store
+.idea/

--- a/app/index.js
+++ b/app/index.js
@@ -10,12 +10,12 @@ module.exports = yeoman.generators.Base.extend({
 
     this.option('skip-install', {
       desc:     'Whether dependencies should be installed',
-      defaults: false,
+      defaults: false
     });
 
     this.option('skip-install-message', {
       desc:     'Whether commands run should be shown',
-      defaults: false,
+      defaults: false
     });
 
     this.sourceRoot(path.join(path.dirname(this.resolved), 'templates/polymer-starter-kit'));
@@ -108,7 +108,7 @@ module.exports = yeoman.generators.Base.extend({
   install: function () {
     this.installDependencies({
       skipInstall: this.options['skip-install'],
-      skipMessage: this.options['skip-install-message'],
+      skipMessage: this.options['skip-install-message']
     });
   }
 });

--- a/bo/index.js
+++ b/bo/index.js
@@ -1,4 +1,4 @@
-"use strict";
+'use strict';
 var yeoman = require('yeoman-generator');
 var path = require('path');
 var exec = require('child_process').exec;
@@ -15,7 +15,6 @@ module.exports = yeoman.generators.Base.extend({
       require: true
     });
 
-    this.option('save');
   },
   init: function () {
     var generator = this;
@@ -35,17 +34,17 @@ module.exports = yeoman.generators.Base.extend({
       function includeImport(imports) {
         var file = generator.readFileAsString('app/elements/elements.html');
         file += '\n<!-- ' + exactName + ' Elements -->\n';
-        if (_.isArray(imports)) {
+        if (Array.isArray(imports)) {
           _.each(imports, function (fileName) {
-            fileName = fileName.replace('\\', '/');
-            if (fileName.indexOf(".html") !== -1) {
+            fileName = fileName.replace(/\\/g, '/');
+            if (path.extname(fileName) === '.html') {
               file += '<link rel="import" href="../bower_components/' + exactName + '/' + fileName + '">\n';
             }
           });
 
         } else {
-          imports = imports.replace('\\', '/');
-          if (imports.indexOf(".html") !== -1) {
+          imports = imports.replace(/\\/g, '/');
+          if (path.extname(imports) === '.html') {
             file += '<link rel="import" href="../bower_components' + exactName + '/' + imports + '">\n';
           }
 
@@ -55,7 +54,7 @@ module.exports = yeoman.generators.Base.extend({
       }
 
       try {
-        var componentBowerFile = generator.readFileAsString('./bower_components/' + exactName + '/bower.json'),
+        var componentBowerFile = generator.readFileAsString(path.join('bower_components/', exactName, '/bower.json')),
           bowerJSON = JSON.parse(componentBowerFile);
 
         generator.writeFileFromString(includeImport(bowerJSON.main || ''), 'app/elements/elements.html');

--- a/bo/index.js
+++ b/bo/index.js
@@ -1,0 +1,70 @@
+"use strict";
+var yeoman = require('yeoman-generator');
+var path = require('path');
+var exec = require('child_process').exec;
+var _ = require('lodash');
+
+module.exports = yeoman.generators.Base.extend({
+  constructor: function () {
+    yeoman.generators.Base.apply(this, arguments);
+
+    // ex: yo polymer:bo -component-name foo will
+    // execute `bower install --save foo`
+    this.argument('component-name', {
+      desc: 'Component to be downloaded through bower',
+      require: true
+    });
+
+    this.option('save');
+  },
+  init: function () {
+    var generator = this;
+
+    generator.componentName = generator['component-name'];
+    var isSubProject = generator.componentName.indexOf('/'),
+
+      //Extract the resolved component name after bower install.
+      exactName = (isSubProject !== -1) ? generator.componentName.match(/[\/*](.*)/)[1] : generator.componentName;
+
+    exec('bower install --save ' + generator.componentName, function (error, stdout, stderr) {
+      if (error) { return console.log(error.message); }
+
+      // Output the bower install log
+      console.log(stdout);
+
+      function includeImport(imports) {
+        var file = generator.readFileAsString('app/elements/elements.html');
+        file += '\n<!-- ' + exactName + ' Elements -->\n';
+        if (_.isArray(imports)) {
+          _.each(imports, function (fileName) {
+            fileName = fileName.replace('\\', '/');
+            if (fileName.indexOf(".html") !== -1) {
+              file += '<link rel="import" href="../bower_components/' + exactName + '/' + fileName + '">\n';
+            }
+          });
+
+        } else {
+          imports = imports.replace('\\', '/');
+          if (imports.indexOf(".html") !== -1) {
+            file += '<link rel="import" href="../bower_components' + exactName + '/' + imports + '">\n';
+          }
+
+        }
+
+        return file;
+      }
+
+      try {
+        var componentBowerFile = generator.readFileAsString('./bower_components/' + exactName + '/bower.json'),
+          bowerJSON = JSON.parse(componentBowerFile);
+
+        generator.writeFileFromString(includeImport(bowerJSON.main || ''), 'app/elements/elements.html');
+
+      } catch (err) {
+        //To catch file / folder missing post bower install
+        console.log(err.message);
+
+      }
+    });
+  }
+});

--- a/bower/index.js
+++ b/bower/index.js
@@ -1,0 +1,1 @@
+module.exports = require('../bo/index.js');

--- a/el/index.js
+++ b/el/index.js
@@ -101,7 +101,7 @@ module.exports = yeoman.generators.Base.extend({
     // Wire up the dependency in elements.html
     if (this.includeImport) {
       var file = this.readFileAsString('app/elements/elements.html');
-      el = el.replace('\\', '/');
+      el = el.replace(/\\/g, '/');
       file += '<link rel="import" href="' + el + '.html">\n';
       this.writeFileFromString(file, 'app/elements/elements.html');
     }

--- a/package.json
+++ b/package.json
@@ -17,7 +17,7 @@
   },
   "dependencies": {
     "chalk": "^1.0.0",
-    "lodash": "^3.3.0",
+    "lodash": "^3.10.1",
     "ncp": "^2.0.0",
     "rimraf": "^2.2.8",
     "validate-element-name": "^1.0.0",

--- a/readme.md
+++ b/readme.md
@@ -42,6 +42,7 @@ Available generators:
 
 - [polymer (aka polymer:app)](#app)
 - [polymer:element](#element-alias-el)
+- [polymer:bower](#bower-alias-bo)
 - [polymer:seed](#seed)
 - [polymer:gh](#gh)
 
@@ -69,18 +70,19 @@ yo polymer:el my-element
 
 **Note: You must pass in an element name, and the name must contain a dash "-"**
 
-One can also include element dependencies to be imported. For instance, if you're creating a `fancy-menu` element which needs to import `paper-button` and `paper-checkbox` as dependencies, you can generate the file like so:
+### Bower (alias: Bo)
+Installs a polymer element through `bower` and appends an import to `app/elements/elements.html`.
 
+Example:
 ```bash
-yo polymer:el fancy-menu paper-button paper-checkbox
+yo polymer:bower my-element
+
+# or use the alias
+
+yo polymer:bo my-element
 ```
 
-#### Options
-
-```
---docs, include iron-component-page docs with your element and demo.html
---path, override default directory structure, ex: --path foo/bar will put your element in app/elements/foo/bar
-```
+**Note: You must pass in an element name.**
 
 ### Seed
 Generates a reusable polymer element based on the [seed-element workflow](https://github.com/polymerelements/seed-element). **This should only be used if you're creating a standalone element repo that you intend to share with others via bower.** If you're just building a Polymer app, stick to the [Element](#element-alias-el) generator.


### PR DESCRIPTION
@robdodson : I've tried adding `yo polymer:bower` sub-generator to install and append polymer-elements through **bower**

### Change Log
* Sub-Generator - **bower** _#alias **bo**_
* **_Updated README.md_** describing the new sub-generator.
* Removed trailing `,` from `app/index.js`

### What's Happening under the hood
1. It's similar to `yo polymer:element` with the only difference being the `element-name` entered is installed via bower.
2. Post Install, the generator fetches the `main` property from **_bower.json_**.
3. Loops through the `main` property, importing the elements to `app/elements/elements.html` 