### PR TITLE
Minor Style Changes & fixes.

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -10,12 +10,12 @@ module.exports = yeoman.generators.Base.extend({
 
     this.option('skip-install', {
       desc:     'Whether dependencies should be installed',
-      defaults: false,
+      defaults: false
     });
 
     this.option('skip-install-message', {
       desc:     'Whether commands run should be shown',
-      defaults: false,
+      defaults: false
     });
 
     this.sourceRoot(path.join(path.dirname(this.resolved), 'templates/polymer-starter-kit'));
@@ -108,7 +108,7 @@ module.exports = yeoman.generators.Base.extend({
   install: function () {
     this.installDependencies({
       skipInstall: this.options['skip-install'],
-      skipMessage: this.options['skip-install-message'],
+      skipMessage: this.options['skip-install-message']
     });
   }
 });

--- a/el/index.js
+++ b/el/index.js
@@ -101,7 +101,7 @@ module.exports = yeoman.generators.Base.extend({
     // Wire up the dependency in elements.html
     if (this.includeImport) {
       var file = this.readFileAsString('app/elements/elements.html');
-      el = el.replace('\\', '/');
+      el = el.replace(/\\/g, '/');
       file += '<link rel="import" href="' + el + '.html">\n';
       this.writeFileFromString(file, 'app/elements/elements.html');
     }

--- a/seed/index.js
+++ b/seed/index.js
@@ -12,17 +12,17 @@ module.exports = yeoman.generators.Base.extend({
 
     this.argument('element-name', {
       desc: 'Tag name of the element and directory to generate.',
-      required: true,
+      required: true
     });
 
     this.option('skip-install', {
       desc: 'Whether bower dependencies should be installed',
-      defaults: false,
+      defaults: false
     });
 
     this.option('skip-install-message', {
       desc: 'Whether commands run should be shown',
-      defaults: false,
+      defaults: false
     });
 
     this.sourceRoot(path.join(path.dirname(this.resolved), 'templates/seed-element'));
@@ -110,7 +110,7 @@ module.exports = yeoman.generators.Base.extend({
     this.installDependencies({
       npm: false,
       skipInstall: this.options['skip-install'],
-      skipMessage: this.options['skip-install-message'],
+      skipMessage: this.options['skip-install-message']
     });
   }
 });


### PR DESCRIPTION
### Minor fixes
1. Removed trailing `,` from `seed/index.js` & `el/index.js`
2. As noted by @sindresorhus : minor fix to `\\` replacement in filename with regex `/\\/g`