### PR TITLE
Remove polymer.html import from element test templates.

### DIFF
--- a/el/templates/test/_bdd.html
+++ b/el/templates/test/_bdd.html
@@ -15,7 +15,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <title><%= elementName %></title>
 
   <script src="../../bower_components/webcomponentsjs/webcomponents.min.js"></script>
-  <link rel="import" href="../../bower_components/polymer/polymer.html">
   <script src="../../bower_components/web-component-tester/browser.js"></script>
   <script src="../../bower_components/test-fixture/test-fixture-mocha.js"></script>
   <link rel="import" href="../../bower_components/test-fixture/test-fixture.html">

--- a/el/templates/test/_tdd.html
+++ b/el/templates/test/_tdd.html
@@ -15,7 +15,6 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
   <title><%= elementName %></title>
 
   <script src="../../bower_components/webcomponentsjs/webcomponents.min.js"></script>
-  <link rel="import" href="../../bower_components/polymer/polymer.html">
   <script src="../../bower_components/web-component-tester/browser.js"></script>
   <script src="../../bower_components/test-fixture/test-fixture-mocha.js"></script>
   <link rel="import" href="../../bower_components/test-fixture/test-fixture.html">


### PR DESCRIPTION
Using `yo polymer:el` with an app generated by `yo polymer` leads to a test initialization failure on Chrome (45 Mac at the time of this writing) due to the double import:

```shell
chrome 45                ✖ Test Suite Initialization

  Failed to execute 'registerElement' on 'Document': Registration failed for type 'dom-module'. A type with that name is already registered.
    <unknown> at   <unknown> at /components/polygerrit/app/bower_components/polymer/polymer-micro.html:263:0
    <unknown> at   <unknown> at /components/polygerrit/app/bower_components/polymer/polymer-micro.html:273:0

chrome 45                ✖ Test Suite Initialization

  Polymer.Base._getExtendedPrototype is not a function
    <unknown> at          desugar at /components/polygerrit/app/bower_components/polymer/polymer-micro.html:70:0
    <unknown> at   window.Polymer at /components/polygerrit/app/bower_components/polymer/polymer-micro.html:57:0
    <unknown> at        <unknown> at /components/polygerrit/app/bower_components/polymer/polymer.html:3202:0
    <unknown> at        <unknown> at /components/polygerrit/app/bower_components/polymer/polymer.html:3255:0

chrome 45                ✖ Test Suite Initialization

  this._desugarBehaviors is not a function
    <unknown> at   HTMLElement.Polymer.Base.registerCallback at /components/polygerrit/app/bower_components/polymer/polymer-micro.html:142:0
    <unknown> at                                    desugar at /components/polygerrit/app/bower_components/polymer/polymer-micro.html:73:0
    <unknown> at                             window.Polymer at /components/polygerrit/app/bower_components/polymer/polymer-micro.html:57:0
    <unknown> at                                  <unknown> at /components/polygerrit/app/elements/change-list/change-list.html:103:0
    <unknown> at                                  <unknown> at /components/polygerrit/app/elements/change-list/change-list.html:165:0
```

~~It’s also questionable whether `webcomponents.min.js` should be included as well since it's included by test/index.html, but I’m not familiar enough with the mechanics or use cases to take a definitive stance.~~ EDIT: nevermind about the webcomponents part :)