### PR TITLE
added error and, fixed tests to yo polymer:el and corrected yo polyme…

### DIFF
--- a/el/index.js
+++ b/el/index.js
@@ -38,6 +38,12 @@ module.exports = yeoman.generators.Base.extend({
         'ex: yo polymer:el my-element'
       ));
     }
+    var isInsideProjectFolder = this.fs.exists(this.destinationPath('app/elements/elements.html'));
+    if (!isInsideProjectFolder) {
+      this.emit('error', new Error(
+        'Generators are to be run from the root of your app'
+      ));
+    }
   },
   askFor: function () {
     var done = this.async();
@@ -106,7 +112,7 @@ module.exports = yeoman.generators.Base.extend({
     // Wire up the dependency in elements.html
     if (this.includeImport) {
       var file = readFileAsString(this.destinationPath('app/elements/elements.html'));
-      el = (this.flags.path || this.elementName) + '/' + this.elementName
+      el = (this.flags.path || this.elementName) + '/' + this.elementName;
       el = el.replace(/\\/g, '/');
       file += '<link rel="import" href="' + el + '.html">\n';
       writeFileFromString(file, this.destinationPath('app/elements/elements.html'));

--- a/element/templates
+++ b/element/templates
@@ -1,0 +1,1 @@
+el/templates/

--- a/test/el-test.js
+++ b/test/el-test.js
@@ -10,21 +10,14 @@ describe('yo polymer:el', function() {
   describe('yo polymer:el test', function () {
 
     before(function (done) {
-      helpers.run(path.join(__dirname, '../app'))
-        .inDir(path.join(__dirname, './tmp'))
-        .withArguments(['--skip-install'])
-        .withPrompts({
-          includeWCT: true
-        })
-        .on('end', done);
-    });
-
-    before(function (done) {
       helpers.run(path.join(__dirname, '../el'))
         .inDir(path.join(__dirname, './tmp'))
         .withArguments(['my-foo'])
         .withPrompts({
           includeImport: false
+        })
+        .on('ready', function(generator){
+          fs.createFileSync(path.join(__dirname, './tmp/app/elements/elements.html'));
         })
         .on('end', done);
     });
@@ -44,6 +37,9 @@ describe('yo polymer:el', function() {
         .withPrompts({
           includeImport: false
         })
+        .on('ready', function(generator){
+          fs.createFileSync(path.join(__dirname, './tmp/app/elements/elements.html'));
+        })
         .on('end', function() {
           assert.fileContent(
             'app/elements/fancy-menu/fancy-menu.html', /<link rel="import" href="..\/..\/bower_components\/iron-ajax\/iron-ajax.html">/
@@ -60,22 +56,15 @@ describe('yo polymer:el', function() {
   describe('yo polymer:el --docs test', function () {
 
     before(function (done) {
-      helpers.run(path.join(__dirname, '../app'))
-        .inDir(path.join(__dirname, './tmp'))
-        .withArguments(['--skip-install'])
-        .withPrompts({
-          includeWCT: true
-        })
-        .on('end', done);
-    });
-
-    before(function (done) {
       helpers.run(path.join(__dirname, '../el'))
         .inDir(path.join(__dirname, './tmp'))
         .withArguments(['docs-el'])
         .withOptions({ 'docs': true })
         .withPrompts({
           includeImport: false
+        })
+        .on('ready', function(generator){
+          fs.createFileSync(path.join(__dirname, './tmp/app/elements/elements.html'));
         })
         .on('end', done);
     });
@@ -94,22 +83,15 @@ describe('yo polymer:el', function() {
   describe('yo polymer:el --path test', function () {
 
     before(function (done) {
-      helpers.run(path.join(__dirname, '../app'))
-        .inDir(path.join(__dirname, './tmp'))
-        .withArguments(['--skip-install'])
-        .withPrompts({
-          includeWCT: true
-        })
-        .on('end', done);
-    });
-
-    before(function (done) {
       helpers.run(path.join(__dirname, '../el'))
         .inDir(path.join(__dirname, './tmp'))
         .withArguments(['path-el'])
         .withOptions({ 'path': 'foo/bar/baz' })
         .withPrompts({
           includeImport: false
+        })
+        .on('ready', function(generator){
+          fs.createFileSync(path.join(__dirname, './tmp/app/elements/elements.html'));
         })
         .on('end', done);
     });
@@ -146,6 +128,9 @@ describe('yo polymer:el', function() {
         .withPrompts({
           includeImport: false,
           testType: 'TDD'
+        })
+        .on('ready', function(generator){
+          fs.createFileSync(path.join(__dirname, './tmp/app/elements/elements.html'));
         })
         .on('end', function(){
           done();
@@ -194,6 +179,9 @@ describe('yo polymer:el', function() {
           includeImport: false,
           testType: 'BDD'
         })
+        .on('ready', function(generator){
+          fs.createFileSync(path.join(__dirname, './tmp/app/elements/elements.html'));
+        })
         .on('end', function(){
           done();
         });
@@ -233,6 +221,9 @@ describe('yo polymer:el', function() {
         .withPrompts({
           includeImport: false,
           testType: 'None'
+        })
+        .on('ready', function(generator){
+          fs.createFileSync(path.join(__dirname, './tmp/app/elements/elements.html'));
         })
         .on('end', function(){
           done();


### PR DESCRIPTION
* Added an error when running ``` yo polymer:el``` outside a PSK root
* Fixed ```yo polymer:element``` by creating a symbolic link
* Fixed tests in for ```yo polymer:el```

The elements.html file  was being created inside
```javascript
before(function (done) {
      helpers.run(path.join(__dirname, '../app'))
```
but was deleted inside:
```javascript
it('creates expected files', function () {
      var expected = [
        'app/elements/my-foo/my-foo.html'
      ];
      assert.file(expected);
    });
```

 raising the new error in ```el/index.js```

To address the issue, instead of creating the ```/app``` data using the helper, I suggest to create a dummy ```elements.html``` file just before the tests begin
```javascript
.on('ready', function(generator){
          fs.createFileSync(path.join(__dirname, './tmp/app/elements/elements.html'));
        })
```