### PR TITLE
Fix incorrect npmignore sniffing

### DIFF
--- a/seed/index.js
+++ b/seed/index.js
@@ -116,7 +116,7 @@ module.exports = yeoman.generators.Base.extend({
 
     // Handle bug where npm has renamed .gitignore to .npmignore
     // https://github.com/npm/npm/issues/3763
-    if (this.fs.exists('.npmignore')) {
+    if (this.fs.exists(this.templatePath('.npmignore'))) {
       this.fs.copy(
         this.templatePath('.npmignore'),
         this.destinationPath('.gitignore')


### PR DESCRIPTION
Fixes #240

Regression introduced in
https://github.com/yeoman/generator-polymer/commit/f9e2d0da558d0b71525e7019b14667d9f2381f42#diff-2018087f584c4398b5c3a23fc0e5f9dbR60

cc @addyosmani @robdodson 


(tested locally this time, by renaming .gitignore to .npmignore) 