### PR TITLE
Omit optional tags from templates

### DIFF
--- a/el/templates/demo.html
+++ b/el/templates/demo.html
@@ -8,19 +8,12 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
-<html>
-  <head>
-    <meta charset="utf-8">
-    <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-    <title><%= elementName %> Demo</title>
-    <script src="../../../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
-    <link rel="import" href="../<%= elementName %>.html">
-  </head>
-  <body>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+<title><%= elementName %> Demo</title>
+<script src="../../../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
+<link rel="import" href="../<%= elementName %>.html">
 
-    <p>An example of <code>&lt;<%= elementName %>&gt;</code>:</p>
+<p>An example of <code>&lt;<%= elementName %>&gt;</code>:</p>
 
-    <<%= elementName %>></<%= elementName %>>
-
-  </body>
-</html>
+<<%= elementName %>></<%= elementName %>>

--- a/el/templates/index.html
+++ b/el/templates/index.html
@@ -8,22 +8,14 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
-<html>
-<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1.0">
 
-  <meta charset="utf-8">
-  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+<script src="../../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
+<link rel="import" href="../../bower_components/iron-component-page/iron-component-page.html">
 
-  <script src="../../bower_components/webcomponentsjs/webcomponents-lite.js"></script>
-  <link rel="import" href="../../bower_components/iron-component-page/iron-component-page.html">
-
-</head>
-<body>
-  <!-- Note: if the main element for this repository doesn't
-       match the folder name, add a src="&lt;main-component&gt;.html" attribute,
-       where &lt;main-component&gt;.html" is a file that imports all of the
-       components you want documented. -->
-  <iron-component-page></iron-component-page>
-
-</body>
-</html>
+<!-- Note: if the main element for this repository doesn't
+     match the folder name, add a src="&lt;main-component&gt;.html" attribute,
+     where &lt;main-component&gt;.html" is a file that imports all of the
+     components you want documented. -->
+<iron-component-page></iron-component-page>

--- a/el/templates/test/bdd.html
+++ b/el/templates/test/bdd.html
@@ -8,22 +8,16 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
+<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+<title><%= elementName %></title>
 
-<html>
-<head>
-  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-  <title><%= elementName %></title>
+<script src="../../bower_components/webcomponentsjs/webcomponents.min.js"></script>
+<script src="../../bower_components/web-component-tester/browser.js"></script>
+<script src="../../bower_components/test-fixture/test-fixture-mocha.js"></script>
+<link rel="import" href="../../bower_components/test-fixture/test-fixture.html">
 
-  <script src="../../bower_components/webcomponentsjs/webcomponents.min.js"></script>
-  <script src="../../bower_components/web-component-tester/browser.js"></script>
-  <script src="../../bower_components/test-fixture/test-fixture-mocha.js"></script>
-  <link rel="import" href="../../bower_components/test-fixture/test-fixture.html">
-
-  <!-- Step 1: import the element to test -->
-  <link rel="import" href="../elements/<%= elementName %>/<%= elementName %>.html">
-
-</head>
-<body>
+<!-- Step 1: import the element to test -->
+<link rel="import" href="../elements/<%= elementName %>/<%= elementName %>.html">
 
 <test-fixture id="basic">
   <template>
@@ -45,6 +39,3 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   });
 </script>
-
-</body>
-</html>

--- a/el/templates/test/tdd.html
+++ b/el/templates/test/tdd.html
@@ -8,22 +8,16 @@ The complete set of contributors may be found at http://polymer.github.io/CONTRI
 Code distributed by Google as part of the polymer project is also
 subject to an additional IP rights grant found at http://polymer.github.io/PATENTS.txt
 -->
+<meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
+<title><%= elementName %></title>
 
-<html>
-<head>
-  <meta name="viewport" content="width=device-width, minimum-scale=1.0, initial-scale=1.0, user-scalable=yes">
-  <title><%= elementName %></title>
+<script src="../../bower_components/webcomponentsjs/webcomponents.min.js"></script>
+<script src="../../bower_components/web-component-tester/browser.js"></script>
+<script src="../../bower_components/test-fixture/test-fixture-mocha.js"></script>
+<link rel="import" href="../../bower_components/test-fixture/test-fixture.html">
 
-  <script src="../../bower_components/webcomponentsjs/webcomponents.min.js"></script>
-  <script src="../../bower_components/web-component-tester/browser.js"></script>
-  <script src="../../bower_components/test-fixture/test-fixture-mocha.js"></script>
-  <link rel="import" href="../../bower_components/test-fixture/test-fixture.html">
-
-  <!-- Step 1: import the element to test -->
-  <link rel="import" href="../elements/<%= elementName %>/<%= elementName %>.html">
-
-</head>
-<body>
+<!-- Step 1: import the element to test -->
+<link rel="import" href="../elements/<%= elementName %>/<%= elementName %>.html">
 
 <test-fixture id="basic">
   <template>
@@ -45,6 +39,3 @@ subject to an additional IP rights grant found at http://polymer.github.io/PATEN
 
   });
 </script>
-
-</body>
-</html>


### PR DESCRIPTION
Per the [spec](http://www.w3.org/TR/2011/WD-html5-20110525/syntax.html#optional-tags), `html` and `body` tags can be omitted under most circumstances.

Sooooooo. Remove them. 👋 bye, tags!