### PR TITLE
Fix seed generator ignore glob

### DIFF
--- a/seed/index.js
+++ b/seed/index.js
@@ -82,10 +82,17 @@ module.exports = yeoman.generators.Base.extend({
 
     this.fs.copy([
         this.templatePath() + '/**',
-        this.templatePath() + '/**/.*',
-        '!**/{bower.json,seed-element.html,.git,.npmignore,test}/**'],
+        this.templatePath() + '/**/.*'],
       this.destinationPath(),
-      { process: renameElement });
+      { 
+        process: renameElement,
+        globOptions: {
+          ignore: [
+            '**/{bower.json,seed-element.html,.npmignore}',
+            '**/{test,.git}/**'
+          ]
+        }
+      });
 
     this.fs.copy(
       this.templatePath('seed-element.html'),

--- a/test/seed-test.js
+++ b/test/seed-test.js
@@ -35,6 +35,16 @@ describe('yo polymer:seed', function() {
       assert.file(expected);
     });
 
+    it('does not create ignored files', function () {
+      var unwanted = [
+        'seed-element.html',
+        '.npmignore',
+        '.git'
+      ];
+
+      assert.noFile(unwanted);
+    });
+
     it('creates the correct bower.json content', function () {
       assert.fileContent('bower.json', /"name": "seed-el"/);
       assert.fileContent('bower.json', /"main": "seed-el.html"/);


### PR DESCRIPTION
Thanks for the awesome generator! I have been using it more of late and it is proving to be a **super** useful tool, so thanks again!

I have been specifically using `yo polymer:seed` and found that the glob negation that is happening ( https://github.com/yeoman/generator-polymer/blob/master/seed/index.js#L86) isn't filtering out the proper paths. Upon closer inspection it seems that in v5 of `node-glob` the negation has to be manually turned on with a `nonegate: true` flag passed to the `globOptions` prop of `fs.copy`.

As I was digging around I also found that they recommended using the `ignore` property of `globOptions` instead (https://github.com/isaacs/node-glob#comments-and-negation). So I wrote a quick PR to address the bug (following the `ignore` prop suggestion) and added a test to verify.