### PR TITLE
Fix typo in gh subgenerator

### DIFF
--- a/gh/index.js
+++ b/gh/index.js
@@ -46,7 +46,7 @@ module.exports = yeoman.Base.extend({
       },
       {
         name: 'connectionType',
-        message: 'Use HTTPS or SSL to connect to GitHub?',
+        message: 'Use HTTPS or SSH to connect to GitHub?',
         default: 'HTTPS'
       },
     ];


### PR DESCRIPTION
The two ways `gp.sh` works are via HTTPS or SSH; not SSL. This bugs me every time I run this sub-generator so decided to PR it.