### PR TITLE
Refactor bower install step to use HTTPS/SSH as defined by user

### DIFF
--- a/gh/templates/gp.sh
+++ b/gh/templates/gp.sh
@@ -42,7 +42,8 @@ echo "{
 }
 " > .bowerrc
 bower install
-bower install git@$hostname:$org/$repo#$branch
+[ "$connectionType" = "https" ] && { bowerUrl=https://$hostname/$org/$repo.git#$branch; true; } || bowerUrl=git@$hostname:$org/$repo#$branch;
+bower install $bowerUrl
 git checkout ${branch} -- demo
 rm bower.json .bowerrc
 rm -rf components/$repo/demo


### PR DESCRIPTION
In #248 I realized the that we were defaulting to `SSL` for the initial download of files.

I just realized that we are also using only `SSL` on the `bower install` for the current repo as well (https://github.com/yeoman/generator-polymer/blob/master/gh/templates/gp.sh#L45)

This PR simply applies the same `https` check that was implemented for the `git clone` url to the `bower install` url.